### PR TITLE
fix(devtools):remove leading underscore from class name

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
@@ -39,6 +39,9 @@ ts_test_library(
 ts_library(
     name = "highlighter",
     srcs = ["highlighter.ts"],
+    deps = [
+        ":utils"
+    ]
 )
 
 ts_library(
@@ -92,6 +95,9 @@ ts_library(
 ts_library(
     name = "utils",
     srcs = ["utils.ts"],
+    deps = [
+        "//packages/core"
+    ]
 )
 
 ts_library(
@@ -126,5 +132,6 @@ ts_library(
         "//devtools/projects/ng-devtools-backend/src/lib/state-serializer",
         "//devtools/projects/protocol",
         "//packages/core",
+        ":utils"
     ],
 )

--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -18,7 +18,7 @@ import {start as startProfiling, stop as stopProfiling} from './hooks/capture';
 import {ComponentTreeNode} from './interfaces';
 import {setConsoleReference} from './set-console-reference';
 import {serializeDirectiveState} from './state-serializer/state-serializer';
-import {runOutsideAngular} from './utils';
+import {runOutsideAngular, stripUnderscore} from './utils';
 
 export const subscribeToClientEvents = (messageBus: MessageBus<Events>): void => {
   messageBus.on('shutdown', shutdownCallback(messageBus));
@@ -229,7 +229,7 @@ const prepareForestForSerialization = (roots: ComponentTreeNode[], includeResolu
                                       null,
           directives: node.directives.map(
               (d) => ({
-                name: d.name,
+                name: stripUnderscore(d.name),
                 id: initializeOrGetDirectiveForestHooks().getDirectiveId(d.instance),
               })),
           children: prepareForestForSerialization(node.children, includeResolutionPath),

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -21,7 +21,8 @@ enum ChangeDetectionStrategy {
 }
 
 import {ComponentTreeNode, DirectiveInstanceType, ComponentInstanceType} from './interfaces';
-import type {ClassProvider, ExistingProvider, FactoryProvider, InjectionToken, Injector, Type, ValueProvider,} from '@angular/core';
+import type {ClassProvider, ExistingProvider, FactoryProvider, Injector, ValueProvider,} from '@angular/core';
+import {stripUnderscore, valueToLabel, isInjectionToken} from './utils';
 
 const ngDebug = () => (window as any).ng;
 export const injectorToId = new WeakMap<Injector|HTMLElement, string>();
@@ -321,30 +322,6 @@ const getDependenciesForDirective = (
   return serializedInjectedServices;
 };
 
-export const valueToLabel = (value: any): string => {
-  if (isInjectionToken(value)) {
-    return `InjectionToken(${value['_desc']})`;
-  }
-
-  if (typeof value === 'object') {
-    return stripUnderscore(value.constructor.name);
-  }
-
-  if (typeof value === 'function') {
-    return stripUnderscore(value.name);
-  }
-
-  return stripUnderscore(value);
-};
-
-function stripUnderscore(str: string): string {
-  if (str.startsWith('_')) {
-    return str.slice(1);
-  }
-
-  return str;
-}
-
 export function serializeInjector(injector: Injector): Omit<SerializedInjector, 'id'>|null {
   const metadata = getInjectorMetadata(injector);
 
@@ -444,9 +421,7 @@ export function getElementInjectorElement(elementInjector: Injector): HTMLElemen
   return getInjectorMetadata(elementInjector)!.source as HTMLElement;
 }
 
-export function isInjectionToken(token: Type<unknown>|InjectionToken<unknown>): boolean {
-  return token.constructor.name === 'InjectionToken';
-}
+
 
 export function isEnvironmentInjector(injector: Injector) {
   const metadata = getInjectorMetadata(injector);

--- a/devtools/projects/ng-devtools-backend/src/lib/highlighter.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/highlighter.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {valueToLabel} from './utils';
+
 let overlay: any;
 let overlayContent: HTMLElement;
 
@@ -60,7 +62,7 @@ export const findComponentAndHost =
 
 // Todo(aleksanderbodurri): this should not be part of the highlighter, move this somewhere else
 export function getDirectiveName(dir: Type<unknown>|undefined|null): string {
-  return dir ? dir.constructor.name : 'unknown';
+  return dir ? valueToLabel(dir.constructor.name) : 'unknown';
 }
 
 export function highlight(el: HTMLElement): void {

--- a/devtools/projects/ng-devtools-backend/src/lib/utils.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/utils.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import { InjectionToken, Type } from "@angular/core";
+
 export const runOutsideAngular = (f: () => any): void => {
   const w = window as any;
   if (!w.Zone || !w.Zone.current) {
@@ -34,3 +36,31 @@ export const isCustomElement = (node: Node) => {
   const tagName = node.tagName.toLowerCase();
   return !!customElements.get(tagName);
 };
+
+export const valueToLabel = (value: any): string => {
+  if (isInjectionToken(value)) {
+    return `InjectionToken(${value['_desc']})`;
+  }
+
+  if (typeof value === 'object') {
+    return stripUnderscore(value.constructor.name);
+  }
+
+  if (typeof value === 'function') {
+    return stripUnderscore(value.name);
+  }
+
+  return stripUnderscore(value);
+};
+
+export function stripUnderscore(str: string): string {
+  if (str.startsWith('_')) {
+    return str.slice(1);
+  }
+
+  return str;
+}
+
+export function isInjectionToken(token: Type<unknown>|InjectionToken<unknown>): boolean {
+  return token.constructor.name === 'InjectionToken';
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In the **components** and **profiler** tabs, directives/components class names have an underscore(_) prepended which is an internal naming pattern.

Issue Number: N/A


## What is the new behavior?
With [@JeanMeche](https://github.com/JeanMeche)' help, underscores are removed from class names.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
